### PR TITLE
added explicit dependency for org.xerial.snappy 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     "io.netty" % "netty" % "3.6.6.Final",
     "org.apache.hadoop" % "hadoop-client" % "2.2.0-cdh5.0.0-beta-2" % "provided" excludeAll(excludeJackson,
       excludeNetty, excludeAsm, excludeCglib),
-	  "org.xerial.snappy" % "snappy-java" % "1.0.4.1"
+    "org.xerial.snappy" % "snappy-java" % "1.0.4.1"
   )
 
   lazy val logbackDeps = Seq(


### PR DESCRIPTION
I was have problem while building spark-jobserver due dependency resolve issue. Adding direct dependency to _org.xerial.snappy_ solved this issue.

```
$ sbt compile
...
[info] Resolving com.sun.jersey#jersey-client;1.9 ...
[error] impossible to get artifacts when data has not been loaded. IvyNode = org.xerial.snappy#snappy-java;1.0.4.1
[info] Resolving com.sun.jersey#jersey-client;1.9 ...
[error] impossible to get artifacts when data has not been loaded. IvyNode = org.xerial.snappy#snappy-java;1.0.4.1
java.lang.IllegalStateException: impossible to get artifacts when data has not been loaded. IvyNode = org.xerial.snappy#snappy-java;1.0.4.1
...
[error] (job-server-tests/*:update) java.lang.IllegalStateException: impossible to get artifacts when data has not been loaded. IvyNode = org.xerial.snappy#snappy-java;1.0.4.1
[error] (job-server/*:update) java.lang.IllegalStateException: impossible to get artifacts when data has not been loaded. IvyNode = org.xerial.snappy#snappy-java;1.0.4.1
[error] Total time: 12 s, completed 2014-03-26 23:25:26
```
