### PR TITLE
Move the path of extra jars to the beginning of the classpath

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,6 +36,7 @@ object JobServerBuild extends Build {
       test in Test <<= (test in Test).dependsOn(packageBin in Compile in jobServerTestJar)
                                      .dependsOn(clean in Compile in jobServerTestJar),
 
+      // Adds the path of extra jars to the front of the classpath  
       fullClasspath in Compile <<= (fullClasspath in Compile).map { classpath =>
         extraJarPaths ++ classpath
       },


### PR DESCRIPTION
This will avoid any conflicts between libraries that are placed on the classpath based on the library dependencies required for spark-jobserver in Build.scala and the libraries within the extra jars (read from the $EXTRA_JARS env variable).
