### PR TITLE
Only store POSTed job configuration

### DIFF
--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -204,7 +204,7 @@ class JobManagerActor(dao: JobDAO,
       }
 
       try {
-        statusActor ! JobStatusActor.JobInit(jobInfo, jobConfig)
+        statusActor ! JobStatusActor.JobInit(jobInfo)
 
         job.validate(sparkContext, jobConfig) match {
           case SparkJobInvalid(reason) => {

--- a/job-server/src/spark.jobserver/JobStatusActor.scala
+++ b/job-server/src/spark.jobserver/JobStatusActor.scala
@@ -1,7 +1,6 @@
 package spark.jobserver
 
 import akka.actor.ActorRef
-import com.typesafe.config.Config
 import com.yammer.metrics.core.Meter
 import ooyala.common.akka.InstrumentedActor
 import ooyala.common.akka.metrics.YammerMetrics
@@ -10,7 +9,7 @@ import scala.util.Try
 import spark.jobserver.io.{ JobInfo, JobDAO }
 
 object JobStatusActor {
-  case class JobInit(jobInfo: JobInfo, jobConfig: Config)
+  case class JobInit(jobInfo: JobInfo)
   case class GetRunningJobStatus()
 }
 
@@ -55,11 +54,10 @@ class JobStatusActor(jobDao: JobDAO) extends InstrumentedActor with YammerMetric
       val jobSubscribers = subscribers.getOrElseUpdate(jobId, newMultiMap())
       events.foreach { event => jobSubscribers.addBinding(event, receiver) }
 
-    case JobInit(jobInfo, jobConfig) =>
+    case JobInit(jobInfo) =>
       // TODO (kelvinchu): Check if the jobId exists in the persistence store already
       if (!infos.contains(jobInfo.jobId)) {
         infos(jobInfo.jobId) = jobInfo
-        jobDao.saveJobConfig(jobInfo.jobId, jobConfig)
       } else {
         sender ! JobInitAlready
       }

--- a/job-server/test/spark.jobserver/JobInfoActorSpec.scala
+++ b/job-server/test/spark.jobserver/JobInfoActorSpec.scala
@@ -37,8 +37,15 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
   }
 
   describe("JobInfoActor") {
+    it("should store a job configuration") {
+      actor ! StoreJobConfig(jobId, jobConfig)
+      expectMsg(JobConfigStored)
+      dao.getJobConfigs.get(jobId) should be (Some(jobConfig))
+    }
+
     it("should return a job configuration when the jobId exists") {
-      dao.saveJobConfig(jobId, jobConfig)
+      actor ! StoreJobConfig(jobId, jobConfig)
+      expectMsg(JobConfigStored)
       actor ! GetJobConfig(jobId)
       expectMsg(jobConfig)
     }

--- a/job-server/test/spark.jobserver/JobStatusActorSpec.scala
+++ b/job-server/test/spark.jobserver/JobStatusActorSpec.scala
@@ -56,13 +56,13 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
     }
 
     it("should not initialize a job more than two times") {
-      actor ! JobInit(jobInfo, jobConfig)
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
+      actor ! JobInit(jobInfo)
       expectMsg(JobInitAlready)
     }
 
     it("should be informed JobStarted until it is unsubscribed") {
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
       actor ! Subscribe(jobId, self, Set(classOf[JobStarted]))
       val msg = JobStarted(jobId, contextName, DateTime.now)
       actor ! msg
@@ -81,14 +81,14 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
 
     it("should be ok to subscribe beofore job init") {
       actor ! Subscribe(jobId, self, Set(classOf[JobStarted]))
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
       val msg = JobStarted(jobId, contextName, DateTime.now)
       actor ! msg
       expectMsg(msg)
     }
 
     it("should be informed JobValidationFailed once") {
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
       actor ! Subscribe(jobId, self, Set(classOf[JobValidationFailed]))
       val msg = JobValidationFailed(jobId, DateTime.now, new Throwable)
       actor ! msg
@@ -99,7 +99,7 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
     }
 
     it("should be informed JobFinished until it is unsubscribed") {
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
       actor ! JobStarted(jobId, contextName, DateTime.now)
       actor ! Subscribe(jobId, self, Set(classOf[JobFinished]))
       val msg = JobFinished(jobId, DateTime.now)
@@ -111,7 +111,7 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
     }
 
     it("should be informed JobErroredOut until it is unsubscribed") {
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
       actor ! JobStarted(jobId, contextName, DateTime.now)
       actor ! Subscribe(jobId, self, Set(classOf[JobErroredOut]))
       val msg = JobErroredOut(jobId, DateTime.now, new Throwable)
@@ -123,7 +123,7 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
     }
 
     it("should update status correctly") {
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
       actor ! GetRunningJobStatus
       expectMsg(Seq(jobInfo))
 
@@ -141,7 +141,7 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
     it("should update JobValidationFailed status correctly") {
       val initTime = DateTime.now
       val jobInfo = JobInfo(jobId, contextName, jarInfo, classPath, initTime, None, None)
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
 
       val failedTime = DateTime.now
       val err = new Throwable
@@ -151,7 +151,7 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
     }
 
     it("should update JobErroredOut status correctly") {
-      actor ! JobInit(jobInfo, jobConfig)
+      actor ! JobInit(jobInfo)
 
       val startTime = DateTime.now
       actor ! JobStarted(jobId, contextName, startTime)

--- a/job-server/test/spark.jobserver/WebApiSpec.scala
+++ b/job-server/test/spark.jobserver/WebApiSpec.scala
@@ -86,7 +86,7 @@ with ScalatestRouteTest with HttpService {
                                                           new IllegalArgumentException("foo")))
       case StartJob(_, _, config, events)     =>
         statusActor ! Subscribe("foo", sender, events)
-        statusActor ! JobStatusActor.JobInit(JobInfo("foo", "context", null, "", dt, None, None), config)
+        statusActor ! JobStatusActor.JobInit(JobInfo("foo", "context", null, "", dt, None, None))
         statusActor ! JobStarted("foo", "context1", dt)
         val map = config.entrySet().asScala.map { entry => (entry.getKey -> entry.getValue.unwrapped) }.toMap
         if (events.contains(classOf[JobResult])) sender ! JobResult("foo", map)


### PR DESCRIPTION
Whenever WebApi receives a JobStarted message, it sends a message to JobInfoActor to store the configuration (just what was POSTed, not the merged one). This is quite different from the previous implementation but in this way I don't have to worry about the configuration being merged before it is passed inside the StartJob message...
Should the configuration be stored also in other cases? E.g. when the job validation fails...
