### PR TITLE
Adds documentation of NamedRDD usage 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We deploy our job server off of this repo at Ooyala and it is tested against CDH
 - Asynchronous and synchronous job API.  Synchronous API is great for low latency jobs!
 - Works with Standalone Spark as well as Mesos
 - Job and jar info is persisted via a pluggable DAO interface
-- Named RDDs to cache and retrieve RDDs by name, improving RRD sharing and reuse among jobs. 
+- Named RDDs to cache and retrieve RDDs by name, improving RDD sharing and reuse among jobs. 
 
 ## Quick start / development mode
 
@@ -107,42 +107,80 @@ In your `build.sbt`, add this to use the job server jar:
 
 	resolvers += "Ooyala Bintray" at "http://dl.bintray.com/ooyala/maven"
 
-	libraryDependencies += "ooyala.cnd" % "job-server" % "0.3.1" % "provided"                                                                                  
+	libraryDependencies += "ooyala.cnd" % "job-server" % "0.3.1" % "provided"
 
 For most use cases it's better to have the dependencies be "provided" because you don't want SBT assembly to include the whole job server jar.
 
 To create a job that can be submitted through the job server, the job must implement the `SparkJob` trait. 
 Your job will look like:
-
-    object SampleJob  extends SparkJob {
-        override def runJob(sc:SparkContext, jobConfig: Config): Any = ???
-        override def validate(sc:SparkContext, config: Contig): SparkJobValidation = ???
-    }
+```scala
+object SampleJob  extends SparkJob {
+    override def runJob(sc:SparkContext, jobConfig: Config): Any = ???
+    override def validate(sc:SparkContext, config: Config): SparkJobValidation = ???
+}
+```
 
 - `runJob` contains the implementation of the Job. The SparkContext is managed by the JobServer and will be provided to the job through this method.
   This releaves the developer from the boiler-plate configuration management that comes with the creation of a Spark job and allows the Job Server to
 manage and re-use contexts.
-- `validate` allows for an initial validation of the context and any provided configuration. If the context and configuration are OK to run the job, returning `spark.jobserver.SparkJobValid` will let the job execute, while returning `spark.jobserver.SparkJobInvalid(reason)` prevents the job from running and provides means to convey the reason of failure. This way, you prevent running jobs that will eventually fail due to missing or wrong configuration and save both time and resources.  
+- `validate` allows for an initial validation of the context and any provided configuration. If the context and configuration are OK to run the job, returning `spark.jobserver.SparkJobValid` will let the job execute, otherwise returning `spark.jobserver.SparkJobInvalid(reason)` prevents the job from running and provides means to convey the reason of failure. In this case, the call immediatly returns an `HTTP/1.1 400 Bad Request` status code.  
+`validate` helps you preventing running jobs that will eventually fail due to missing or wrong configuration and save both time and resources.  
+
+Let's try running our sample job with an invalid configuration:
+
+    curl -i -d "bad.input=abc" 'localhost:8090/jobs?appName=test&classPath=spark.jobserver.WordCountExample'
+
+    HTTP/1.1 400 Bad Request
+    Server: spray-can/1.2.0
+    Date: Tue, 10 Jun 2014 22:07:18 GMT
+    Content-Type: application/json; charset=UTF-8
+    Content-Length: 929
+
+    {
+      "status": "VALIDATION FAILED",
+      "result": {
+        "message": "No input.string config param",
+        "errorClass": "java.lang.Throwable",
+        "stack": ["spark.jobserver.JobManagerActor$$anonfun$spark$jobserver$JobManagerActor$$getJobFuture$4.apply(JobManagerActor.scala:212)", 
+        "scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)", 
+        "scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)", 
+        "akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:42)",
+        "akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:386)", 
+        "scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)", 
+        "scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)", 
+        "scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)", 
+        "scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)"]
+      }
+    }
 
 ### Using Named RDDs
 Named RDDs are a way to easily share RDDs among job. Using this facility, computed RDDs can be cached with a given name and later on retrieved.
 To use this feature, the SparkJob needs to mixin `NamedRddSupport`:
-
-    object SampleNamedRDDJob  extends SparkJob with NamedRddSupport {
-        override def runJob(sc:SparkContext, jobConfig: Config): Any = ???
-        override def validate(sc:SparkContext, config: Contig): SparkJobValidation = ???
-     }
+```scala
+object SampleNamedRDDJob  extends SparkJob with NamedRddSupport {
+    override def runJob(sc:SparkContext, jobConfig: Config): Any = ???
+    override def validate(sc:SparkContext, config: Contig): SparkJobValidation = ???
+}
+```
 
 Then in the implementation of the job, RDDs can be stored with a given name:
-
-    this.namedRdds.update("french_dictionary", frenchDictionaryRDD)
-
+```scala
+this.namedRdds.update("french_dictionary", frenchDictionaryRDD)
+```
 Other job running in the same context can retrieve and use this RDD later on:
-
-    val rdd = this.namedRdds.get[(String, String)]("french_dictionary").get 
-
+```scala
+val rdd = this.namedRdds.get[(String, String)]("french_dictionary").get 
+```
 (note the explicit type provided to get. This will allow to cast the retrieved RDD that otherwise is of type RDD[_])
 
+For jobs that depends on a named RDDs it's a good practice to check for the existence of the NamedRDD in the `validate` method as explained earlier:
+```scala   
+def validate(sc:SparkContext, config: Contig): SparkJobValidation = {
+  ...
+  val rdd = this.namedRdds.get[(Long, scala.Seq[String])]("dictionary")
+  if (rdd.isDefined) SparkJobValid else SparkJobInvalid(s"Missing named RDD [dictionary]")
+}
+```
 
 ## Deployment
 


### PR DESCRIPTION
NamedRDDs are an interesting feature of the JobServer. The use required some looking through the source code.
This PR adds introductory documentation about the NamedRDD feature:
- description
- code example how to create a job with NamedRDD support
- storing an RDD by name
- retrieving an RDD by name
