### PR TITLE
Bug fix, handle null in akka-app:ooyala.commom.akka.web.JsonUtils

### DIFF
--- a/job-server/test/spark.jobserver/JobManagerSpec.scala
+++ b/job-server/test/spark.jobserver/JobManagerSpec.scala
@@ -178,7 +178,7 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll with
       }
     }
 
-    ignore("should properly serialize case classes and other job jar classes") {
+    it("should properly serialize case classes and other job jar classes") {
       manager ! JobManagerActor.Initialize
       expectMsgClass(classOf[JobManagerActor.Initialized])
 


### PR DESCRIPTION
The /jobs route in WebApi.scala uses the spray API and ooyala.common.akka.web.JsonUtils to return JSON information about the jobs. It turns out that if you any instance object is null, the spray API throws a NPE and that particular route is no longer available and returns the message 'There was an internal server error.'
