### PR TITLE
Named rdd docs review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,28 +156,31 @@ Let's try running our sample job with an invalid configuration:
 ### Using Named RDDs
 Named RDDs are a way to easily share RDDs among job. Using this facility, computed RDDs can be cached with a given name and later on retrieved.
 To use this feature, the SparkJob needs to mixin `NamedRddSupport`:
-    ```scala
-    object SampleNamedRDDJob  extends SparkJob with NamedRddSupport {
-        override def runJob(sc:SparkContext, jobConfig: Config): Any = ???
-        override def validate(sc:SparkContext, config: Contig): SparkJobValidation = ???
-     }
+```scala
+object SampleNamedRDDJob  extends SparkJob with NamedRddSupport {
+    override def runJob(sc:SparkContext, jobConfig: Config): Any = ???
+    override def validate(sc:SparkContext, config: Contig): SparkJobValidation = ???
+}
+```
 
 Then in the implementation of the job, RDDs can be stored with a given name:
-
-    this.namedRdds.update("french_dictionary", frenchDictionaryRDD)
-
+```scala
+this.namedRdds.update("french_dictionary", frenchDictionaryRDD)
+```
 Other job running in the same context can retrieve and use this RDD later on:
-
-    val rdd = this.namedRdds.get[(String, String)]("french_dictionary").get 
-
+```scala
+val rdd = this.namedRdds.get[(String, String)]("french_dictionary").get 
+```
 (note the explicit type provided to get. This will allow to cast the retrieved RDD that otherwise is of type RDD[_])
 
 For jobs that depends on a named RDDs it's a good practice to check for the existence of the NamedRDD in the `validate` method as explained earlier:
-    def validate(sc:SparkContext, config: Contig): SparkJobValidation = {
-      ...
-      val rdd = this.namedRdds.get[(Long, scala.Seq[String])]("dictionary")
-      if (rdd.isDefined) SparkJobValid else SparkJobInvalid(s"Missing named RDD [dictionary]")
-    }
+```scala   
+def validate(sc:SparkContext, config: Contig): SparkJobValidation = {
+  ...
+  val rdd = this.namedRdds.get[(Long, scala.Seq[String])]("dictionary")
+  if (rdd.isDefined) SparkJobValid else SparkJobInvalid(s"Missing named RDD [dictionary]")
+}
+```
 
 ## Deployment
 


### PR DESCRIPTION
Process PR comments
Adds new CURL example for the configuration failure case and code snippets for named RDDs
MD formatting for Scala code
