### PR TITLE
Add SPARK_CONF_HOME in server_start.sh for CDH5

### DIFF
--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -43,8 +43,7 @@ if [ -z "$SPARK_HOME" ]; then
 fi
 
 if [ -z "$SPARK_CONF_HOME" ]; then
-  echo "Please set SPARK_CONF_HOME or put it in $appdir/settings.sh first"
-  exit 1
+  SPARK_CONF_HOME=$SPARK_HOME/conf
 fi
 
 # Pull in other env vars in spark config, such as MESOS_NATIVE_LIBRARY

--- a/job-server/config/local.sh.template
+++ b/job-server/config/local.sh.template
@@ -8,6 +8,6 @@ APP_GROUP=spark
 INSTALL_DIR=/home/spark/job-server
 LOG_DIR=/var/log/job-server
 SPARK_HOME=/home/spark/spark-0.8.0
-SPARK_CONF_HOME=/home/spark/spark-0.8.0/conf
+SPARK_CONF_HOME=$SPARK_HOME/conf
 # Only needed for Mesos deploys
 SPARK_EXECUTOR_URI=/home/spark/spark-0.8.0.tar.gz


### PR DESCRIPTION
When installing Spark from CDH5 repository, Spark configutations are insalled to /etc/spark/conf.
It is different from Spark binaries (/usr/lib/spark), so separate configuration variable is needed.
