### PR TITLE
Removed string duplication in startup script

### DIFF
--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -55,8 +55,8 @@ if [ -f "$PIDFILE" ] && kill -0 $(cat "$PIDFILE"); then
 fi
 
 if [ -z "$LOG_DIR" ]; then
-  echo "LOG_DIR empty; logging will go to /tmp/job-server"
   LOG_DIR=/tmp/job-server
+  echo "LOG_DIR empty; logging will go to $LOG_DIR"
 fi
 mkdir -p $LOG_DIR
 


### PR DESCRIPTION
It's a tiny enhancement that doesn't add much, but I think it's pretty harmless

The way the code was before, changing the default value of LOG_DIR would not affect the warning message, so if we wanted to change the default, we'd have to change it twice.
