### PR TITLE
fix the noisy spray logging issue

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,9 +20,12 @@ object Dependencies {
     // to use this one
     "com.typesafe.akka" %% "akka-slf4j" % "2.2.4" % "provided",
     "io.spray" %% "spray-json" % "1.2.5",
-    "io.spray" % "spray-can" % "1.2.0",
-    "io.spray" % "spray-routing" % "1.2.0",
-    "io.spray" % "spray-client" % "1.2.0",
+    // upgrade version from 1.2.0 to 1.2.1 to solve the logging noise issue
+    // details here: https://groups.google.com/forum/#!msg/spray-user/YN2ocRzwhY0/KJOegaDIep8J
+    // NOTE: DO NOT upgrade to 1.2.2 since it is incompatiable and will cause tests fail
+    "io.spray" % "spray-can" % "1.2.1",
+    "io.spray" % "spray-routing" % "1.2.1",
+    "io.spray" % "spray-client" % "1.2.1",
     yammerDeps
   ) ++ yodaDeps
 


### PR DESCRIPTION
Without this fix, job server generates the following annoying log every 12 seconds which pollute the log file. 
[2014-11-14 21:15:36,760] WARN  erver.HttpServerConnection [] [akka://JobServer/user/IO-HTTP/listener-0/164882] - Connection is already closed, dropping command ConfirmedClose

The fix is to upgrade the Spray version. See details here:  
https://groups.google.com/forum/#!msg/spray-user/YN2ocRzwhY0/KJOegaDIep8J
