### PR TITLE
add more job serve metrics

### DIFF
--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -102,8 +102,8 @@ class JobManagerActor(dao: JobDAO,
         // Load side jars first in case the ContextFactory comes from it
         getSideJars(contextConfig).foreach { jarUri => jarLoader.addURL(new URL(convertJarUriSparkToJava(jarUri))) }
         sparkContext = createContextFromConfig()
-        // metric for monitoring #executors in spark context
-        MetricsWrapper.newGauge(getClass, "num-sparkExecutor", sparkContext.getExecutorStorageStatus.size)
+        // metric for monitoring the number of executors in spark context
+        MetricsWrapper.newGauge(getClass, "num-spark-executors", sparkContext.getExecutorStorageStatus.size)
 
         sparkEnv = SparkEnv.get
         rddManagerActor = context.actorOf(Props(classOf[RddManagerActor], sparkContext), "rdd-manager-actor")

--- a/job-server/src/spark.jobserver/JobStatusActor.scala
+++ b/job-server/src/spark.jobserver/JobStatusActor.scala
@@ -64,7 +64,7 @@ class JobStatusActor(jobDao: JobDAO) extends InstrumentedActor {
       // TODO (kelvinchu): Check if the jobId exists in the persistence store already
       if (!infos.contains(jobInfo.jobId)) {
         infos(jobInfo.jobId) = jobInfo
-        metricJobSubmissionRate.mark();
+        metricJobSubmissionRate.mark()
       } else {
         sender ! JobInitAlready
       }


### PR DESCRIPTION
1. added a metric to monitor the number of spark executors. It will help a lot for Exploration team to check the health status of job server
2. Added a meter to measure the job submission rate. It can help detect if job server is hang (when no new job submission is accepted)
