### PR TITLE
Fix for exception on serialization of emtpy maps.

### DIFF
--- a/akka-app/src/ooyala.common.akka/web/JsonUtils.scala
+++ b/akka-app/src/ooyala.common.akka/web/JsonUtils.scala
@@ -21,16 +21,21 @@ object JsonUtils {
       case s: String => JsString(s)
       case x: Seq[_] => seqFormat[Any].write(x)
       // Get the type of map keys from the first key, translate the rest the same way
-      case m: Map[_, _] => m.keys.head match {
-        case sym: Symbol =>
-          val map = m.asInstanceOf[Map[Symbol, _]]
-          val pairs = map.map { case (sym, v) => (sym.name -> write(v)) }
-          JsObject(pairs)
-        case s: String => mapFormat[String, Any].write(m.asInstanceOf[Map[String, Any]])
-        case a: Any =>
-          val map = m.asInstanceOf[Map[Any, _]]
-          val pairs = map.map { case (sym, v) => (sym.toString -> write(v)) }
-          JsObject(pairs)
+      case m: Map[_, _] => if (m.isEmpty) {
+        // Translates an emtpy map
+        JsObject(Map[String, JsValue]())
+      } else {
+        m.keys.head match {
+          case sym: Symbol =>
+            val map = m.asInstanceOf[Map[Symbol, _]]
+            val pairs = map.map { case (sym, v) => (sym.name -> write(v))}
+            JsObject(pairs)
+          case s: String => mapFormat[String, Any].write(m.asInstanceOf[Map[String, Any]])
+          case a: Any =>
+            val map = m.asInstanceOf[Map[Any, _]]
+            val pairs = map.map { case (sym, v) => (sym.toString -> write(v))}
+            JsObject(pairs)
+        }
       }
       case a: Array[_] => seqFormat[Any].write(a.toSeq)
       case true        => JsTrue

--- a/akka-app/test/ooyala.common.akka/web/JsonUtilsSpec.scala
+++ b/akka-app/test/ooyala.common.akka/web/JsonUtilsSpec.scala
@@ -29,6 +29,18 @@ class JsonUtilsSpec extends FunSpec with ShouldMatchers {
       JsonUtils.listFromJson(json) should equal (batch)
     }
 
+    it("should serialize empty maps") {
+      val expected1 = """{"a":1,"b":{}}"""
+      import JsonUtils._
+      // Serializes a simple map that contains an emtpy map.
+      Map("a" -> 1, "b" -> Map()).toJson.compactPrint should equal (expected1)
+
+      val expected2 = """{"a":1,"b":{"a1":1,"b1":{}}}"""
+      // Serializes a map that embeds an empty map in a deeper level.
+      Map("a" -> 1, "b" -> Map("a1" -> 1, "b1" -> Map())).toJson
+        .compactPrint should equal (expected2)
+    }
+
     it("should serialize some other types") {
       val expected1 = """{"1":[1,2,3]}"""
       import JsonUtils._


### PR DESCRIPTION
This is to fix exception on serialization of empty maps.  m.keys is null for an empty map.