### PR TITLE
added JobCacheDAO to hold job information in memory cache only.

### DIFF
--- a/job-server/src/spark.jobserver/io/JobCacheDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobCacheDAO.scala
@@ -1,0 +1,145 @@
+package spark.jobserver.io
+
+import java.io._
+
+import com.typesafe.config._
+import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
+import spark.jobserver.util.LRUCache
+
+import scala.collection.mutable
+import scala.util.Try
+
+/**
+ * Store job information (JobInfo, config) in memory cache only, but jar files still in file system.
+ *
+ *
+ * @param config
+ */
+class JobCacheDAO(config: Config) extends JobDAO {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val charsetName = "UTF-8"
+
+  // appName to its set of upload times. Decreasing times in the seq.
+  private val apps = mutable.HashMap.empty[String, Seq[DateTime]]
+  // jobId to its (JobInfo, config)
+  private val jobs = new LRUCache[String, (JobInfo, Config)](this.getClass,
+    Try(config.getInt("spark.jobserver.cachedao.size")).getOrElse(500))
+
+  private val rootDir = getOrElse(config.getString("spark.jobserver.cachedao.rootdir"),
+    "/tmp/spark-jobserver/cachedao/data")
+  private val rootDirFile = new File(rootDir)
+  logger.info("rootDir is " + rootDirFile.getAbsolutePath)
+
+  private val jarsFile = new File(rootDirFile, "jars.data")
+  private var jarsOutputStream: DataOutputStream = null
+
+  init()
+
+  private def init() {
+    // create the date directory if it doesn't exist
+    if (!rootDirFile.exists()) {
+      if (!rootDirFile.mkdirs()) {
+        throw new RuntimeException("Could not create directory " + rootDir)
+      }
+    }
+
+    // read back all apps info during startup
+    if (jarsFile.exists()) {
+      val in = new DataInputStream(new BufferedInputStream(new FileInputStream(jarsFile)))
+      try {
+        while (true) {
+          val jarInfo = readJarInfo(in)
+          addJar(jarInfo.appName, jarInfo.uploadTime)
+        }
+      } catch {
+        case e: EOFException => // do nothing
+
+      } finally {
+        in.close()
+      }
+    }
+
+    // Don't buffer the stream. I want the apps meta data log directly into the file.
+    // Otherwise, server crash will lose the buffer data.
+    jarsOutputStream = new DataOutputStream(new FileOutputStream(jarsFile, true))
+  }
+
+  override def saveJar(appName: String, uploadTime: DateTime, jarBytes: Array[Byte]) {
+    // The order is important. Save the jar file first and then log it into jobsFile.
+    val outFile = new File(rootDir, createJarName(appName, uploadTime) + ".jar")
+    val bos = new BufferedOutputStream(new FileOutputStream(outFile))
+    try {
+      logger.debug("Writing {} bytes to file {}", jarBytes.size, outFile.getPath)
+      bos.write(jarBytes)
+      bos.flush()
+    } finally {
+      bos.close()
+    }
+
+    // log it into jobsFile
+    writeJarInfo(jarsOutputStream, JarInfo(appName, uploadTime))
+
+    // track the new jar in memory
+    addJar(appName, uploadTime)
+  }
+
+  private def writeJarInfo(out: DataOutputStream, jarInfo: JarInfo) {
+    out.writeUTF(jarInfo.appName)
+    out.writeLong(jarInfo.uploadTime.getMillis)
+  }
+
+  private def readJarInfo(in: DataInputStream) = JarInfo(in.readUTF, new DateTime(in.readLong))
+
+  private def addJar(appName: String, uploadTime: DateTime) {
+    if (apps.contains(appName)) {
+      apps(appName) = uploadTime +: apps(appName) // latest time comes first
+    } else {
+      apps(appName) = Seq(uploadTime)
+    }
+  }
+
+  def getApps: Map[String, DateTime] = apps.map {
+    case (appName, uploadTimes) =>
+      appName -> uploadTimes.head
+    }.toMap
+
+  override def retrieveJarFile(appName: String, uploadTime: DateTime): String =
+    new File(rootDir, createJarName(appName, uploadTime) + ".jar").getAbsolutePath
+
+  private def createJarName(appName: String, uploadTime: DateTime): String =
+    appName + "-" + uploadTime.toString().replace(':', '_')
+
+  override def saveJobInfo(jobInfo: JobInfo) {
+    jobs.synchronized {
+      jobs.get(jobInfo.jobId) match {
+        case Some((_, config)) => jobs.put(jobInfo.jobId, (jobInfo, config))
+        case None => jobs.put(jobInfo.jobId, (jobInfo, null))
+      }
+    }
+  }
+
+  private def readError(in: DataInputStream) = {
+    val error = in.readUTF()
+    if (error == "") None else Some(new Throwable(error))
+  }
+
+  override def getJobInfos: Map[String, JobInfo] = jobs.toMap.map {case (id, (jobInfo, _)) => (id, jobInfo)}
+
+  override def getJobInfosLimit(limit: Int): Map[String, JobInfo] = getJobInfos.takeRight(limit)
+
+  override def getJobInfo(jobId: String): Option[JobInfo] =  jobs.get(jobId).map(_._1)
+
+  override def saveJobConfig(jobId: String, config: Config) {
+    jobs.synchronized {
+      jobs.get(jobId) match {
+        case Some((jobInfo, _)) => jobs.put(jobId, (jobInfo, config))
+        case None => jobs.put(jobId, (null, config))
+      }
+    }
+  }
+
+  override def getJobConfigs: Map[String, Config] = jobs.toMap.map {case (id, (_, config)) => (id, config)}
+
+}

--- a/job-server/src/spark.jobserver/util/LRUCache.scala
+++ b/job-server/src/spark.jobserver/util/LRUCache.scala
@@ -1,8 +1,10 @@
 package spark.jobserver.util
 
 import java.util.Map.Entry
-import java.lang.ref.SoftReference
+
 import ooyala.common.akka.metrics.MetricsWrapper
+
+import scala.collection.JavaConversions._
 
 /**
  * A convenience class to define a Least-Recently-Used Cache with a maximum size.
@@ -62,4 +64,6 @@ class LRUCache[K, V](cacheHolderClass: Class[_],
       metricHit.inc
       Some(vv)
   }
+
+  def toMap = mapAsScalaMap(cache).toMap
 }

--- a/job-server/src/test/resources/local.test.jobcachedao.conf
+++ b/job-server/src/test/resources/local.test.jobcachedao.conf
@@ -1,0 +1,12 @@
+# This file contains test settings for: JobSqlDAOSpec
+
+spark.jobserver {
+  # Number of job results to keep per JobResultActor/context
+  job-result-cache-size = 5000
+
+  jobdao = spark.jobserver.io.JobCacheDAO
+
+  cachedao {
+    rootdir = /tmp/spark-jobserver-test/cachedao/data
+  }
+}

--- a/job-server/test/spark.jobserver/io/JobCacheDAOSpec.scala
+++ b/job-server/test/spark.jobserver/io/JobCacheDAOSpec.scala
@@ -1,0 +1,165 @@
+package spark.jobserver.io
+
+import java.io.File
+
+import com.google.common.io.Files
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.apache.commons.io.FileUtils
+import org.joda.time.DateTime
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{BeforeAndAfter, FunSpec}
+import spark.jobserver.TestJarFinder
+
+class JobCacheDAOSpec extends TestJarFinder with FunSpec with ShouldMatchers with BeforeAndAfter {
+  private val config = ConfigFactory.load("local.test.jobcachedao.conf")
+
+  var dao: JobCacheDAO = _
+
+  // *** TEST DATA ***
+  val time: DateTime = new DateTime()
+  val throwable: Throwable = new Throwable("test-error")
+  // jar test data
+  val jarInfo: JarInfo = genJarInfo(false, false)
+  val jarBytes: Array[Byte] = Files.toByteArray(testJar)
+  var jarFile: File = new File(config.getString("spark.jobserver.cachedao.rootdir"),
+                               createJarName(jarInfo.appName, jarInfo.uploadTime) + ".jar")
+
+  // jobInfo test data
+  val jobInfoNoEndNoErr:JobInfo = genJobInfo(jarInfo, false, false, false)
+  val expectedJobInfo = jobInfoNoEndNoErr
+  val jobInfoSomeEndNoErr: JobInfo = genJobInfo(jarInfo, true, false, false)
+  val jobInfoNoEndSomeErr: JobInfo = genJobInfo(jarInfo, false, true, false)
+  val jobInfoSomeEndSomeErr: JobInfo = genJobInfo(jarInfo, true, true, false)
+
+  // job config test data
+  val jobId: String = jobInfoNoEndNoErr.jobId
+  val jobConfig: Config = ConfigFactory.parseString("{marco=pollo}")
+  val expectedConfig: Config = ConfigFactory.empty().withValue("marco", ConfigValueFactory.fromAnyRef("pollo"))
+
+  private def createJarName(appName: String, uploadTime: DateTime): String = appName + "-" + uploadTime.toString().replace(':', '_')
+
+  // Helper functions and closures!!
+  private def genJarInfoClosure = {
+    var appCount: Int = 0
+    var timeCount: Int = 0
+
+    def genTestJarInfo(newAppName: Boolean, newTime: Boolean): JarInfo = {
+      appCount = appCount + (if (newAppName) 1 else 0)
+      timeCount = timeCount + (if (newTime) 1 else 0)
+
+      val app = "test-appName" + appCount
+      val upload = if (newTime) time.plusMinutes(timeCount) else time
+
+      JarInfo(app, upload)
+    }
+
+    genTestJarInfo _
+  }
+
+  private def genJobInfoClosure = {
+    var count: Int = 0
+
+    def genTestJobInfo(jarInfo: JarInfo, hasEndTime: Boolean, hasError: Boolean, isNew:Boolean): JobInfo = {
+      count = count + (if (isNew) 1 else 0)
+
+      val id: String = "test-id" + count
+      val contextName: String = "test-context"
+      val classPath: String = "test-classpath"
+      val startTime: DateTime = time
+
+      val noEndTime: Option[DateTime] = None
+      val someEndTime: Option[DateTime] = Some(time) // Any DateTime Option is fine
+      val noError: Option[Throwable] = None
+      val someError: Option[Throwable] = Some(throwable)
+
+      val endTime: Option[DateTime] = if (hasEndTime) someEndTime else noEndTime
+      val error: Option[Throwable] = if (hasError) someError else noError
+
+      JobInfo(id, contextName, jarInfo, classPath, startTime, endTime, error)
+    }
+
+    genTestJobInfo _
+  }
+
+  def genJarInfo = genJarInfoClosure
+  def genJobInfo = genJobInfoClosure
+  //**********************************
+
+  before {
+    FileUtils.deleteDirectory(new File(config.getString("spark.jobserver.cachedao.rootdir")))
+    dao = new JobCacheDAO(config)
+    jarFile.delete()
+  }
+
+  describe("save and get the jars") {
+    it("should be able to save one jar and get it back") {
+      // check the pre-condition
+      jarFile.exists() should equal (false)
+
+      // save
+      dao.saveJar(jarInfo.appName, jarInfo.uploadTime, jarBytes)
+
+      // read it back
+      val apps = dao.getApps
+
+      // test
+      jarFile.exists() should equal (true)
+      apps.keySet should equal (Set(jarInfo.appName))
+      apps(jarInfo.appName) should equal (jarInfo.uploadTime)
+    }
+  }
+
+  describe("saveJobConfig() and getJobConfigs() tests") {
+    it("should provide an empty map on getJobConfigs() for an empty CONFIGS table") {
+      (Map.empty[String, Config]) should equal (dao.getJobConfigs)
+    }
+
+    it("should save and get the same config") {
+      // save job config
+      dao.saveJobConfig(jobId, jobConfig)
+
+      // get all configs
+      val configs = dao.getJobConfigs
+
+      // test
+      configs.keySet should equal (Set(jobId))
+      configs(jobId) should equal (expectedConfig)
+    }
+
+    it("should save and get the large config") {
+      val total = 5000
+      val str = "{" + (1 to total).map(i => s"key-$i=value-$i").mkString(",") + "}"
+
+      str.getBytes.length > 65535 should equal (true)
+
+      val jobConfig: Config = ConfigFactory.parseString(str)
+      // save job config
+      dao.saveJobConfig(jobId, jobConfig)
+
+      // get all configs
+      val configs = dao.getJobConfigs
+
+      // test
+      configs.keySet should equal (Set(jobId))
+      configs(jobId).entrySet().size() should equal (total)
+    }
+  }
+
+  describe("Basic saveJobInfo() and getJobInfos() tests") {
+    it("should provide an empty map on getJobInfos() for an empty JOBS table") {
+      (Map.empty[String, JobInfo]) should equal (dao.getJobInfos)
+    }
+
+    it("should save a new JobInfo and get the same JobInfo") {
+      // save JobInfo
+      dao.saveJobInfo(jobInfoNoEndNoErr)
+
+      // get all JobInfos
+      val jobs = dao.getJobInfos
+
+      // test
+      jobs.keySet should equal (Set(jobId))
+      jobs(jobId) should equal (expectedJobInfo)
+    }
+  }
+}


### PR DESCRIPTION
newly added properties for JobCacheDAO:
   spark.jobserver.cachedao.size => size of in memory cache (default to 500)
   spark.jobserver.cachedao.rootdir => directory to store jar files (default to "/tmp/spark-jobserver/cachedao/data")

@theel 