### PR TITLE
Migration to LRU+TTL Guava cache in JobResultActor + metrics

### DIFF
--- a/akka-app/src/ooyala.common.akka/metrics/MetricsWrapper.scala
+++ b/akka-app/src/ooyala.common.akka/metrics/MetricsWrapper.scala
@@ -17,7 +17,7 @@ object MetricsWrapper {
   // Registers JVM metrics for monitoring
   JvmMetricsWrapper.registerJvmMetrics(registry)
 
-  def startDatadogReporter(config: DatadogConfig) = {
+  def startDatadogReporter(config: DatadogConfig): Unit = {
     val transportOpt: Option[Transport] = config.agentPort.map {
       port =>
         logger.debug("Datadog reporter: datadog agent port - " + port)

--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -10,6 +10,9 @@ spark {
     # Number of job results to keep per JobResultActor/context
     job-result-cache-size = 5000
 
+    # TTL for cache antries to avoid high memory usage
+    job-result-cache-ttl-seconds = 600
+
     jobdao = spark.jobserver.io.JobFileDAO
 
     filedao {

--- a/job-server/src/spark.jobserver/util/GuavaCacheUtils.scala
+++ b/job-server/src/spark.jobserver/util/GuavaCacheUtils.scala
@@ -1,0 +1,37 @@
+package spark.jobserver.util
+
+import java.util.concurrent.TimeUnit
+
+import com.google.common.cache.{CacheBuilder, Cache => GuavaCache}
+import com.typesafe.config.Config
+import ooyala.common.akka.metrics.MetricsWrapper
+
+object GuavaCacheUtils {
+  def buildCache[K,V](cacheSize: Int, ttlSeconds: Long): GuavaCache[K,V] = {
+    CacheBuilder.newBuilder
+      .maximumSize(cacheSize)
+      .expireAfterAccess(ttlSeconds, TimeUnit.SECONDS)
+      .recordStats()
+      .build()
+      .asInstanceOf[GuavaCache[K,V]]
+  }
+
+  def buildCache[K,V](config: Config): GuavaCache[K,V] =
+    buildCache(
+      config.getInt("spark.jobserver.job-result-cache-size"),
+      config.getLong("spark.jobserver.job-result-cache-ttl-seconds")
+    )
+
+  //pimp my cache
+  class WrappedCache[K,V](cache: GuavaCache[K,V]) {
+    def withMetrics(klass: Class[_]): GuavaCache[K,V] = {
+      MetricsWrapper.newGauge(klass, "cache-hit",  cache.stats.hitCount())
+      MetricsWrapper.newGauge(klass, "cache-miss", cache.stats.missCount())
+      MetricsWrapper.newGauge(klass, "cache-eviction", cache.stats.evictionCount())
+      MetricsWrapper.newGauge(klass, "cache-request", cache.stats.requestCount())
+      cache
+    }
+  }
+
+  implicit def toWrappedCache[K,V](cache: GuavaCache[K,V]): WrappedCache[K,V] = new WrappedCache[K,V](cache)
+}

--- a/job-server/src/test/resources/local.test.jobcachedao.conf
+++ b/job-server/src/test/resources/local.test.jobcachedao.conf
@@ -4,6 +4,8 @@ spark.jobserver {
   # Number of job results to keep per JobResultActor/context
   job-result-cache-size = 5000
 
+  job-result-cache-ttl-seconds = 600
+
   jobdao = spark.jobserver.io.JobCacheDAO
 
   cachedao {

--- a/job-server/src/test/resources/local.test.jobfiledao.conf
+++ b/job-server/src/test/resources/local.test.jobfiledao.conf
@@ -4,6 +4,8 @@ spark.jobserver {
   # Number of job results to keep per JobResultActor/context
   job-result-cache-size = 5000
 
+  job-result-cache-ttl-seconds = 600
+
   jobdao = spark.jobserver.io.JobFileDAO
 
   filedao {

--- a/job-server/test/spark.jobserver/JobManagerSpec.scala
+++ b/job-server/test/spark.jobserver/JobManagerSpec.scala
@@ -14,12 +14,14 @@ object JobManagerSpec {
   import collection.JavaConverters._
 
   val JobResultCacheSize = 30
+  val JobResultCacheTtlSeconds = 60
   val NumCpuCores = Runtime.getRuntime.availableProcessors()  // number of cores to allocate. Required.
   val MemoryPerNode = "512m"  // Executor memory per node, -Xmx style eg 512m, 1G, etc.
   val MaxJobsPerContext = 2
   val config = {
     val ConfigMap = Map(
       "spark.jobserver.job-result-cache-size" -> JobResultCacheSize,
+      "spark.jobserver.job-result-cache-ttl-seconds" -> JobResultCacheTtlSeconds,
       "num-cpu-cores" -> NumCpuCores,
       "memory-per-node" -> MemoryPerNode,
       "spark.jobserver.max-jobs-per-context" -> MaxJobsPerContext,

--- a/job-server/test/spark.jobserver/JobResultActorSpec.scala
+++ b/job-server/test/spark.jobserver/JobResultActorSpec.scala
@@ -1,15 +1,13 @@
 package spark.jobserver
 
-import akka.actor.{Props, PoisonPill, ActorRef, ActorSystem}
-import akka.testkit.{TestKit, ImplicitSender}
-import com.codahale.metrics.Counter
-import ooyala.common.akka.metrics.MetricsWrapper
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{ImplicitSender, TestActorRef, TestKit}
 import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.{FunSpec, BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec}
 
 
 object JobResultActorSpec {
-  val system = ActorSystem("test")
+  val system = ActorSystem("job-result-actor-test")
 }
 
 class JobResultActorSpec extends TestKit(JobResultActorSpec.system) with ImplicitSender
@@ -18,111 +16,67 @@ with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
   import CommonMessages._
 
   override def afterAll() {
-    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(JobResultActorSpec.system)
-  }
-
-  // Metrics for job result cache
-  private val metricCacheHitName = "spark.jobserver.JobResultActor.cache-hit"
-  private val metricCacheMissName = "spark.jobserver.JobResultActor.cache-miss"
-  var metricCacheHit: Counter = _
-  var metricCacheMiss: Counter = _
-  var actor: ActorRef = _
-
-  // Create a new supervisor and FileDAO / working directory with every test, so the state of one test
-  // never interferes with the other.
-  before {
-    // Resets the metrics for the job result cache
-    MetricsWrapper.getRegistry.remove(metricCacheHitName)
-    MetricsWrapper.getRegistry.remove(metricCacheMissName)
-    MetricsWrapper.getRegistry.counter(metricCacheHitName)
-    MetricsWrapper.getRegistry.counter(metricCacheMissName)
-
-    val counters = MetricsWrapper.getRegistry.getCounters
-    metricCacheHit = counters.get(metricCacheHitName)
-    metricCacheMiss = counters.get(metricCacheMissName)
-
-    actor = system.actorOf(Props[JobResultActor])
-  }
-
-  after {
-    ooyala.common.akka.AkkaTestUtils.shutdownAndWait(actor)
+    TestKit.shutdownActorSystem(JobResultActorSpec.system)
   }
 
   describe("JobResultActor") {
     it("should return error if non-existing jobs are asked") {
-      actor ! GetJobResult("jobId")
-      expectMsg(NoSuchJobId)
+      withActor { actor =>
+        actor ! GetJobResult("jobId")
+        expectMsg(NoSuchJobId)
+      }
     }
 
     it("should get back existing result") {
-      actor ! JobResult("jobId", 10)
-      actor ! GetJobResult("jobId")
-      expectMsg(JobResult("jobId", 10))
+      withActor { actor =>
+        actor ! JobResult("jobId", 10)
+        actor ! GetJobResult("jobId")
+        expectMsg(JobResult("jobId", 10))
+      }
     }
 
     it("should be informed only once by subscribed result") {
-      actor ! Subscribe("jobId", self, Set(classOf[JobResult]))
-      actor ! JobResult("jobId", 10)
-      expectMsg(JobResult("jobId", 10))
+      withActor { actor =>
+        actor ! Subscribe("jobId", self, Set(classOf[JobResult]))
+        actor ! JobResult("jobId", 10)
+        expectMsg(JobResult("jobId", 10))
 
-      actor ! JobResult("jobId", 20)
-      expectNoMsg()   // shouldn't get it again
+        actor ! JobResult("jobId", 20)
+        expectNoMsg() // shouldn't get it again
+      }
     }
 
     it("should not be informed unsubscribed result") {
-      actor ! Subscribe("jobId", self, Set(classOf[JobResult]))
-      actor ! Unsubscribe("jobId", self)
-      actor ! JobResult("jobId", 10)
-      expectNoMsg()
+      withActor { actor =>
+        actor ! Subscribe("jobId", self, Set(classOf[JobResult]))
+        actor ! Unsubscribe("jobId", self)
+        actor ! JobResult("jobId", 10)
+        expectNoMsg()
+      }
     }
 
     it("should not publish if do not subscribe to JobResult events") {
-      actor ! Subscribe("jobId", self, Set(classOf[JobValidationFailed], classOf[JobErroredOut]))
-      actor ! JobResult("jobId", 10)
-      expectNoMsg()
+      withActor { actor =>
+        actor ! Subscribe("jobId", self, Set(classOf[JobValidationFailed], classOf[JobErroredOut]))
+        actor ! JobResult("jobId", 10)
+        expectNoMsg()
+      }
     }
 
     it("should return error if non-existing subscription is unsubscribed") {
-      actor ! Unsubscribe("jobId", self)
-      expectMsg(NoSuchJobId)
+      withActor{ actor =>
+        actor ! Unsubscribe("jobId", self)
+        expectMsg(NoSuchJobId)
+      }
     }
   }
 
-  describe("JobResultActor cache") {
-    it("should increase cache hit count") {
-      metricCacheHit.getCount should equal(0)
-      metricCacheMiss.getCount should equal(0)
-
-      actor ! JobResult("jobId", 10)
-      actor ! GetJobResult("jobId")
-      expectMsg(JobResult("jobId", 10))
-      // Hits the job result cache for the first time
-      metricCacheHit.getCount should equal(1)
-      metricCacheMiss.getCount should equal(0)
-
-      actor ! GetJobResult("jobId")
-      expectMsg(JobResult("jobId", 10))
-      // Hits the job result cache for the second time
-      metricCacheHit.getCount should equal(2)
-      metricCacheMiss.getCount should equal(0)
-    }
-
-    it("should increase cache miss count") {
-      metricCacheHit.getCount should equal(0)
-      metricCacheMiss.getCount should equal(0)
-
-      actor ! JobResult("jobId", 10)
-      actor ! GetJobResult("NoJobId")
-      expectMsg(NoSuchJobId)
-      metricCacheHit.getCount should equal(0)
-      // Misses the job result cache for the first time
-      metricCacheMiss.getCount should equal(1)
-
-      actor ! GetJobResult("NoJobId")
-      expectMsg(NoSuchJobId)
-      metricCacheHit.getCount should equal(0)
-      // Misses the job result cache for the second time
-      metricCacheMiss.getCount should equal(2)
+  def withActor[T](f: ActorRef => T): T ={
+    val actor = TestActorRef(new JobResultActor)
+    try {
+      f(actor)
+    } finally {
+      ooyala.common.akka.AkkaTestUtils.shutdownAndWait(actor)
     }
   }
 }

--- a/job-server/test/spark.jobserver/JobResultCacheSpec.scala
+++ b/job-server/test/spark.jobserver/JobResultCacheSpec.scala
@@ -1,0 +1,131 @@
+package spark.jobserver
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.testkit.{ImplicitSender, TestActorRef, TestKit}
+import com.typesafe.config.ConfigFactory
+import ooyala.common.akka.metrics.MetricsWrapper
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec}
+
+
+object JobResultCacheSpec {
+  val config = ConfigFactory.parseString("""
+    spark {
+      jobserver.job-result-cache-size = 10
+      jobserver.job-result-cache-ttl-seconds = 1
+    }
+    """)
+
+  val system = ActorSystem("job-result-cache-test", config)
+}
+
+class JobResultCacheSpec extends TestKit(JobResultCacheSpec.system) with ImplicitSender
+  with FunSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll {
+
+  import CommonMessages._
+
+  override def afterAll() {
+    TestKit.shutdownActorSystem(JobResultCacheSpec.system)
+  }
+
+  // Metrics for job result cache
+  private val metricCacheHitName = "spark.jobserver.JobResultActor.cache-hit"
+  private val metricCacheMissName = "spark.jobserver.JobResultActor.cache-miss"
+  private val metricCacheRequestName = "spark.jobserver.JobResultActor.cache-request"
+  private val metricCacheEvictionName = "spark.jobserver.JobResultActor.cache-eviction"
+
+  before {
+    MetricsWrapper.getRegistry.remove(metricCacheHitName)
+    MetricsWrapper.getRegistry.remove(metricCacheMissName)
+    MetricsWrapper.getRegistry.remove(metricCacheRequestName)
+    MetricsWrapper.getRegistry.remove(metricCacheEvictionName)
+  }
+
+  describe("JobResultActor cache") {
+    it("should increase cache hit count") {
+      withActor { actor =>
+
+        actor ! JobResult("jobId", 10)
+        actor ! GetJobResult("jobId")
+        expectMsg(JobResult("jobId", 10))
+        // Hits the job result cache for the first time
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheHitName).getValue should equal(1)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheMissName).getValue should equal(0)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheRequestName).getValue should equal(1)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(0)
+
+        actor ! GetJobResult("jobId")
+        expectMsg(JobResult("jobId", 10))
+        // Hits the job result cache for the second time
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheHitName).getValue should equal(2)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheMissName).getValue should equal(0)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheRequestName).getValue should equal(2)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(0)
+      }
+    }
+
+    it("should increase cache miss count") {
+      withActor { actor =>
+        actor ! JobResult("jobId", 10)
+        actor ! GetJobResult("NoJobId")
+        expectMsg(NoSuchJobId)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheHitName).getValue should equal(0)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheMissName).getValue should equal(1)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheRequestName).getValue should equal(1)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(0)
+
+        actor ! GetJobResult("NoJobId")
+        expectMsg(NoSuchJobId)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheHitName).getValue should equal(0)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheMissName).getValue should equal(2)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheRequestName).getValue should equal(2)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(0)
+      }
+    }
+
+    it("should evict entries according to configured TTL") {
+      withActor { actor =>
+        val jobResultActor = system.actorOf(Props[JobResultActor])
+
+        (1 to 10).foreach { i =>
+          actor ! JobResult(s"jobId_$i", 10)
+        }
+
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(0)
+
+        //from javadoc: requested entries may be evicted on each cache modification, on occasional
+        //cache accesses, or on calls to Cache#cleanUp
+        Thread.sleep(1500)
+        actor ! JobResult("jobId", 10)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(10)
+        actor ! GetJobResult("jobId_1")
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheMissName).getValue should equal(1)
+      }
+    }
+
+    it("should evict entries according to configured cache size") {
+      withActor { actor =>
+        (1 to 10).foreach { i =>
+          actor ! JobResult(s"jobId_$i", 10)
+        }
+
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(0)
+
+        actor ! JobResult("jobId_X", 10)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(1)
+
+        actor ! JobResult("jobId_Y", 10)
+        MetricsWrapper.getRegistry.getGauges.get(metricCacheEvictionName).getValue should equal(2)
+      }
+    }
+  }
+
+  def withActor[T](f: ActorRef => T): T ={
+    val actor = TestActorRef(new JobResultActor)
+    try {
+      f(actor)
+    } finally {
+      ooyala.common.akka.AkkaTestUtils.shutdownAndWait(actor)
+    }
+  }
+}

--- a/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
+++ b/job-server/test/spark.jobserver/LocalContextSupervisorSpec.scala
@@ -19,6 +19,7 @@ object LocalContextSupervisorSpec {
         memory-per-node = 512m      # Executor memory per node, -Xmx style eg 512m, 1G, etc.
       }
       jobserver.job-result-cache-size = 100
+      jobserver.job-result-cache-ttl-seconds = 60
       jobserver.context-creation-timeout = 5 s
       jobserver.context-factory = spark.jobserver.util.DefaultSparkContextFactory
       contexts {

--- a/job-server/test/spark.jobserver/SparkWebUiActorSpec.scala
+++ b/job-server/test/spark.jobserver/SparkWebUiActorSpec.scala
@@ -32,6 +32,7 @@ object SparkWebUiActorSpec {
         memory-per-node = 512m      # Executor memory per node, -Xmx style eg 512m, 1G, etc.
       }
       jobserver.job-result-cache-size = 100
+      jobserver.job-result-cache-ttl-seconds = 60
       jobserver.context-creation-timeout = 5 s
       jobserver.context-factory = spark.jobserver.util.DefaultSparkContextFactory
       contexts {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8


### PR DESCRIPTION
This PR addresses the issue with using LRU only cache of large size. When multiple job results of bigger size are stored in memory there's no way to evict them until new results are placed into the cache. High memory pressure caused by large cache leads to slow GC and inability to place new results into the cache. Job Server gets stuck and hangs trying to perform GC.

This PR introduces LRU+TTL cache which allows limiting not only number of entries in the cache but keys TTL and leads to a smoother eviction and lower memory pressure. The cache implementation used is Guava cache which comes with a set of useful cache statistics useful to monitor (cache metrics reporting is a part of this PR too).